### PR TITLE
Feature/user can update location event details

### DIFF
--- a/travel-event-host-app/src/app/api/endpoint-validation/schemas/registration-validation.schema.ts
+++ b/travel-event-host-app/src/app/api/endpoint-validation/schemas/registration-validation.schema.ts
@@ -1,5 +1,6 @@
+import { locationUpdateValidationSchema } from '@/lib/yup-validators/profile-update/location-update/location-update-validator';
 import { User } from '@/models/user';
-import { ObjectSchema, number, object, string } from 'yup';
+import { ObjectSchema, object, string } from 'yup';
 
 interface RegistrationUser extends Omit<User, 'id' | '_id' | 'isAdmin' | 'imageUrl' | 'bio'> {}
 
@@ -13,16 +14,7 @@ export const registrationValidationSchema: ObjectSchema<RegistrationUser> = obje
     .min(2, 'lastName is too short')
     .max(50, 'lastName is too long'),
   email: string().email('Invalid email address').required('email is required'),
-  location: object({
-    country: string().required(),
-    state: string().required(),
-    city: string().required(),
-    place_id: string().required(),
-    coords: object({
-      lat: number().required(),
-      lng: number().required(),
-    }).required(),
-  }).required(),
+  location: locationUpdateValidationSchema,
   password: string()
     .required('password is required')
     .min(8, 'password is too short')

--- a/travel-event-host-app/src/app/api/users/[id]/location/route.ts
+++ b/travel-event-host-app/src/app/api/users/[id]/location/route.ts
@@ -1,0 +1,36 @@
+import { locationUpdateValidationSchema } from '@/lib/yup-validators/profile-update/location-update/location-update-validator';
+import { UserRepository } from '@/schemas/user';
+import mongoose from 'mongoose';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  const { id } = params;
+
+  if (!mongoose.Types.ObjectId.isValid(id))
+    return NextResponse.json({ message: 'Invalid ObjectId format' }, { status: 400 });
+
+  // Validate the request body
+  const requestBody = await req.json();
+  try {
+    await locationUpdateValidationSchema.validate(requestBody, { abortEarly: false });
+  } catch (validationError: any) {
+    return NextResponse.json(validationError, { status: 400 });
+  }
+
+  // We expect country, state, city, place_id, formattedAddress, coords from the request body and they shall be patched 😏
+  const user = await UserRepository.findById(id);
+  if (user) {
+    const { country, state, city, place_id, formattedAddress, coords } = requestBody;
+    user.location = {
+      country,
+      state,
+      city,
+      place_id,
+      formattedAddress,
+      coords,
+    };
+    await user.save();
+    return NextResponse.json({ message: `User ${id} updated.` }, { status: 200 });
+  }
+  return NextResponse.json({ message: `User ${id} not found.` }, { status: 404 });
+}

--- a/travel-event-host-app/src/app/clients/user/user-client.ts
+++ b/travel-event-host-app/src/app/clients/user/user-client.ts
@@ -1,3 +1,4 @@
+import { LocationData } from '@/models/location';
 import { SecureUser } from '@/types/secure-user';
 
 export const UserClient = {
@@ -38,6 +39,20 @@ export const UserClient = {
 
     if (!req.ok) {
       throw new Error('Error: Cannot patch user profile');
+    }
+  },
+  patchUserLocationById: async (userId: string, locationData: LocationData): Promise<void> => {
+    const endPoint: string = `/api/users/${userId}/location`;
+    const req = await fetch(endPoint, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(locationData),
+    });
+
+    if (!req.ok) {
+      throw new Error('Error: Cannot patch user location');
     }
   },
 };

--- a/travel-event-host-app/src/app/users/[id]/page.tsx
+++ b/travel-event-host-app/src/app/users/[id]/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 import { EventClient } from '@/app/clients/event/event-client';
 import { UserClient } from '@/app/clients/user/user-client';
+import { getLocationPostDataFromGeocoderResult } from '@/app/integration/google-maps-api/address-helper';
 import theme from '@/app/theme';
 import { EventsSection } from '@/components/events-section/Events-section';
 import { ProfileEditor } from '@/components/profile-editor/ProfileEditor';
 import { Spinner } from '@/components/spinner/Spinner';
 import { useAuthContext } from '@/lib/auth-context';
 import { AuthStatus } from '@/lib/auth-status';
+import { LocationData } from '@/models/location';
 import { UserEvent } from '@/models/user-event';
 import { EventTimeLine } from '@/types/event-timeline';
 import { SecureUser } from '@/types/secure-user';
@@ -30,24 +32,78 @@ export default function UserPortalPage({ params: { id } }: UserPortalPageProps) 
   const [error, setError] = useState<string | undefined>(undefined);
   const { status, session, update } = useAuthContext();
 
+  const [hostedEventsPageNumber, setHostedEventsPageNumber] = useState<number>(1);
+  const [upcomingEventsPageNumber, setUpcomingEventsPageNumber] = useState<number>(1);
+  const [pastEventsPageNumber, setPastEventsPageNumber] = useState<number>(1);
+
   useEffect(() => {
     fetchUser();
+    fetchUserUpcomingEvents();
+    fetchUserHostedEvents();
+    fetchUserPastEvents();
   }, []);
+
+  useEffect(() => {
+    fetchUserHostedEvents();
+  }, [hostedEventsPageNumber]);
+
+  useEffect(() => {
+    fetchUserUpcomingEvents();
+  }, [upcomingEventsPageNumber]);
+
+  useEffect(() => {
+    fetchUserPastEvents();
+  }, [pastEventsPageNumber]);
 
   const fetchUser = async (showLoading: boolean = true) => {
     try {
       showLoading && setIsLoading(true);
       const fetchedUser = await UserClient.getUserById(id);
-      const upcomingEvents = await EventClient.getEventsByUserId(id, EventTimeLine.Upcoming);
-      const userPastEvents = await EventClient.getEventsByUserId(id, EventTimeLine.Past);
-      // Get the events hosted by the user
-      const hostedEvents = await EventClient.getEventsBySearchQuery(undefined, undefined, id);
-
       setUser(fetchedUser);
-      setUpcomingEvents(upcomingEvents!);
-      setPastEvents(userPastEvents!);
-      setHostedEvents(hostedEvents!);
       showLoading && setIsLoading(false);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  const fetchUserHostedEvents = async () => {
+    try {
+      const fetchedHostedEvents = await EventClient.getEventsBySearchQuery(
+        undefined,
+        undefined,
+        id,
+        hostedEventsPageNumber,
+        3,
+      );
+      setHostedEvents([...hostedEvents, ...fetchedHostedEvents!]);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  const fetchUserUpcomingEvents = async () => {
+    try {
+      const fetchedUpcomingEvents = await EventClient.getEventsByUserId(
+        id,
+        EventTimeLine.Upcoming,
+        upcomingEventsPageNumber,
+        3,
+      );
+      setUpcomingEvents([...upcomingEvents, ...fetchedUpcomingEvents!]);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  const fetchUserPastEvents = async () => {
+    try {
+      const fetchedPastEvents = await EventClient.getEventsByUserId(
+        id,
+        EventTimeLine.Past,
+        pastEventsPageNumber,
+        3,
+      );
+      setPastEvents([...pastEvents, ...fetchedPastEvents!]);
     } catch (e: any) {
       setError(e.message);
     }
@@ -58,25 +114,41 @@ export default function UserPortalPage({ params: { id } }: UserPortalPageProps) 
     deleteImageUrl?: boolean,
   ) => {
     // Send patch request to update the user's profile
-    if (status === AuthStatus.Authenticated) {
-      try {
-        const { firstName, lastName, bio, imageUrl } = formValues;
+    if (status !== AuthStatus.Authenticated) return;
+    try {
+      const { firstName, lastName, bio, imageUrl } = formValues;
 
-        await UserClient.patchUserProfileById(session?.user?._id!, {
-          firstName: firstName!,
-          lastName: lastName!,
-          bio: bio!,
-          imageUrl: imageUrl!,
-          deleteImageUrl,
-        });
-        await fetchUser(false);
-        // Update the session
-        if (update) {
-          await update();
-        }
-      } catch (e: any) {
-        setError(e.message);
+      await UserClient.patchUserProfileById(session?.user?._id!, {
+        firstName: firstName!,
+        lastName: lastName!,
+        bio: bio!,
+        imageUrl: imageUrl!,
+        deleteImageUrl,
+      });
+      await fetchUser(false);
+      // Update the session
+      if (update) {
+        await update();
       }
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  const handleUserLocationUpdate = async (location: google.maps.places.PlaceResult | null) => {
+    if (!location) return;
+    if (status !== AuthStatus.Authenticated) return;
+
+    const locationData: LocationData = getLocationPostDataFromGeocoderResult(
+      location as google.maps.GeocoderResult,
+    );
+    try {
+      await UserClient.patchUserLocationById(session?.user?._id!, locationData);
+      // Refresh the user
+      await fetchUser(false);
+      if (update) await update();
+    } catch (e: any) {
+      setError(e.message);
     }
   };
 
@@ -101,6 +173,7 @@ export default function UserPortalPage({ params: { id } }: UserPortalPageProps) 
               editDisabled={session?.user?._id !== id}
               isLoading={isLoading}
               onProfileUpdate={handleProfileUpdate}
+              onLocationUpdate={handleUserLocationUpdate}
             />
           )}
         </Box>
@@ -116,33 +189,43 @@ export default function UserPortalPage({ params: { id } }: UserPortalPageProps) 
           },
         }}
       >
-        {/* Do we want just any user to see some user's upcoming events? */}
+        {/* Hosted events can be public? The upcoming and past events are for user's eyes only*/}
         {hostedEvents && hostedEvents.length > 0 && (
-          <Box>
+          <Box mb={2}>
             <EventsSection
               title="Events I'm hosting"
               hostedEvents={hostedEvents}
-              onLoadMoreEventsButtonClicked={() => {}}
+              onLoadMoreEventsButtonClicked={() =>
+                setHostedEventsPageNumber(hostedEventsPageNumber + 1)
+              }
               isLoading={isLoading}
             />
           </Box>
         )}
-        <Box>
-          <EventsSection
-            title='Upcoming events'
-            hostedEvents={upcomingEvents}
-            onLoadMoreEventsButtonClicked={() => {}}
-            isLoading={isLoading}
-          />
-        </Box>
-        <Box mt={3} mb={5}>
-          <EventsSection
-            title='Past events'
-            hostedEvents={pastEvents}
-            onLoadMoreEventsButtonClicked={() => {}}
-            isLoading={isLoading}
-          />
-        </Box>
+        {status === AuthStatus.Authenticated && session?.user?._id === id && (
+          <Box>
+            <EventsSection
+              title='Upcoming events'
+              hostedEvents={upcomingEvents}
+              onLoadMoreEventsButtonClicked={() =>
+                setUpcomingEventsPageNumber(upcomingEventsPageNumber + 1)
+              }
+              isLoading={isLoading}
+            />
+          </Box>
+        )}
+        {status === AuthStatus.Authenticated && session?.user?._id === id && (
+          <Box mt={3} mb={5}>
+            <EventsSection
+              title='Past events'
+              hostedEvents={pastEvents}
+              onLoadMoreEventsButtonClicked={() =>
+                setPastEventsPageNumber(pastEventsPageNumber + 1)
+              }
+              isLoading={isLoading}
+            />
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/travel-event-host-app/src/components/avatar/user-avatar/UserAvatar.tsx
+++ b/travel-event-host-app/src/components/avatar/user-avatar/UserAvatar.tsx
@@ -33,7 +33,7 @@ export default function UserAvatar({
   const [isErrorImage, setIsErrorImage] = useState<boolean>(false);
 
   return (
-    <Box>
+    <Box display='flex' justifyContent={'center'}>
       <ButtonBase
         onClick={handleAvatarClicked}
         sx={{

--- a/travel-event-host-app/src/components/event/event-card/Event-card.tsx
+++ b/travel-event-host-app/src/components/event/event-card/Event-card.tsx
@@ -100,9 +100,12 @@ export function EventCard({ hostedEvent, onCardClick }: EventCardProps) {
                       marginTop: '10px',
                       paddingBottom: '10px',
                     },
+                    [theme.breakpoints.down(380)]: {
+                      WebkitLineClamp: 3,
+                    },
                   }}
                 >
-                  {hostedEvent.description || 'Mock event description'}
+                  {hostedEvent.description}
                 </CustomResponsiveTypoGraphy>
               </Box>
             </Box>
@@ -187,7 +190,7 @@ function CalendarDateComponent({ date }: { date: Date }) {
 
 // This will handle the responsive typography for the event card title and description
 const CustomResponsiveTypoGraphy = styled(Typography)(({ theme }) => ({
-  fontSize: '0.5rem',
+  fontSize: '0.7rem',
   [theme.breakpoints.up(380)]: {
     fontSize: '0.9rem',
   },

--- a/travel-event-host-app/src/components/event/event-card/Event-card.tsx
+++ b/travel-event-host-app/src/components/event/event-card/Event-card.tsx
@@ -122,10 +122,7 @@ export function EventCard({ hostedEvent, onCardClick }: EventCardProps) {
 */
 function getEventImage(imageUrl?: string): string {
   if (imageUrl) return imageUrl;
-
-  const mockImageCount = 3; // number of mock event images in the mock-images folder
-  const randomImageNumber = Math.floor(Math.random() * mockImageCount) + 1; // random number between 1 and however many mock images there are
-  return `/images/event/mock-images/mock-image-0${randomImageNumber}.svg`; // returns the path to the random mock event image
+  return `/images/event/mock-images/mock-image-01.svg`; // returns the path to the random mock event image
 }
 
 /**

--- a/travel-event-host-app/src/components/profile-editor/ProfileEditor.tsx
+++ b/travel-event-host-app/src/components/profile-editor/ProfileEditor.tsx
@@ -146,6 +146,7 @@ export function ProfileEditor({
           justifyContent={'center'}
           alignSelf={'center'}
           width={'100%'}
+          flexDirection={'column'}
         >
           <UserAvatar
             user={user}
@@ -158,8 +159,10 @@ export function ProfileEditor({
           />
           {!editDisabled && (
             // Photo upload button
-            <Box>
-              <ImagePicker buttonTitle='Choose Image' onImageSelected={handleAvatarImageChange} />
+            <Box display='flex' justifyContent={'center'} flexDirection={'column'}>
+              <Box>
+                <ImagePicker buttonTitle='Choose Image' onImageSelected={handleAvatarImageChange} />
+              </Box>
               {user?.imageUrl && (
                 <Box display={'flex'} justifyContent={'center'} mt={'10px'}>
                   <Button
@@ -186,6 +189,7 @@ export function ProfileEditor({
           flexDirection={'column'}
           gap={1}
           pr={'1%'}
+          width={'100%'}
           sx={{
             [theme.breakpoints.down(430)]: {
               marginTop: 2,

--- a/travel-event-host-app/src/lib/yup-validators/profile-update/location-update/location-update-validator.ts
+++ b/travel-event-host-app/src/lib/yup-validators/profile-update/location-update/location-update-validator.ts
@@ -1,0 +1,14 @@
+import { number, object, string } from 'yup';
+
+// This is used for signup and for update, coming into the API request body
+export const locationUpdateValidationSchema = object({
+  country: string().required(),
+  state: string().required(),
+  city: string().required(),
+  place_id: string().required(),
+  formattedAddress: string().required(),
+  coords: object({
+    lat: number().required(),
+    lng: number().required(),
+  }).required(),
+}).required();

--- a/travel-event-host-app/src/models/location.ts
+++ b/travel-event-host-app/src/models/location.ts
@@ -1,0 +1,11 @@
+export interface LocationData {
+  country: string;
+  state: string;
+  city: string;
+  formattedAddress: string;
+  coords: {
+    lat: number;
+    lng: number;
+  };
+  place_id: string;
+}

--- a/travel-event-host-app/src/models/user-event.ts
+++ b/travel-event-host-app/src/models/user-event.ts
@@ -1,4 +1,5 @@
 import { Category } from '@/lib/category';
+import { LocationData } from './location';
 
 export interface UserEvent {
   _id: string;
@@ -10,17 +11,7 @@ export interface UserEvent {
     userId: string;
     timeStamp: Date;
   }[];
-  location: {
-    country: string;
-    state: string;
-    city: string;
-    formattedAddress: string;
-    coords: {
-      lat: number;
-      lng: number;
-    };
-    place_id: string;
-  };
+  location: LocationData;
   startDate: Date;
   endDate: Date;
   categories: Category[];

--- a/travel-event-host-app/src/models/user.ts
+++ b/travel-event-host-app/src/models/user.ts
@@ -1,3 +1,5 @@
+import { LocationData } from './location';
+
 export interface User {
   _id: string;
   firstName: string;
@@ -6,15 +8,6 @@ export interface User {
   email: string;
   password: string;
   bio?: string;
-  location?: {
-    country?: string;
-    state?: string;
-    city?: string;
-    coords?: {
-      lat?: number;
-      lng?: number;
-    };
-    place_id: string;
-  };
+  location?: LocationData;
   isAdmin?: boolean;
 }

--- a/travel-event-host-app/src/schemas/user.ts
+++ b/travel-event-host-app/src/schemas/user.ts
@@ -28,6 +28,7 @@ const userSchema = new Schema<User>(
       country: String,
       state: String,
       city: String,
+      formattedAddress: String,
       coords: { lat: mongoose.Types.Decimal128, lng: mongoose.Types.Decimal128 },
       place_id: String,
     },


### PR DESCRIPTION
Styling fixes to
- User profile shows the user's location.
- Authenticated user can update their location using the Address search
- Added pagination on the user profile (upcoming, past, and hosted events)
- upcoming and past events are hidden for users viewing an user page that isn't their own